### PR TITLE
Fix client.getConsumption

### DIFF
--- a/src/com/sugestio/client/call/GetConsumptionCall.java
+++ b/src/com/sugestio/client/call/GetConsumptionCall.java
@@ -18,8 +18,8 @@ import com.sun.jersey.api.client.WebResource.Builder;
 
 public class GetConsumptionCall extends Call implements Callable<SugestioResult<Consumption>> {
 	
-	public GetConsumptionCall(Client jClient, SugestioConfig config, String itemId) {
-        super(jClient, config, ResourceType.CONSUMPTION, null, itemId, null);        
+	public GetConsumptionCall(Client jClient, SugestioConfig config, String consumptionId) {
+        super(jClient, config, ResourceType.CONSUMPTION, null, null, consumptionId);        
     }
 
     @Override


### PR DESCRIPTION
Previously the `consumptionId` was stored in the `itemId` variable instead, resulting in a null value when the URL was being built. Making a request for any consumption by ID would thus fail.

This PR fixes that issue.